### PR TITLE
Removed feature flag from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Follow the instructions under the section "Setup and Configuration" in https://w
 ### Linux Users
 The latest version of SourceClear agent only supports C++ projects build on Linux platforms. If you are using a Linux OS, you can scan this project by running
 
-`SRCCLR_CPP=true srcclr scan --url https://github.com/srcclr/example-cpp-makefile`
+`srcclr scan --url https://github.com/srcclr/example-cpp-makefile`
 
 ### Non-Linux users
 For non-linux users, there is a Dockerfile in this repo that builds a Linux container image with this project in it. The steps to setup and test are as follow:
@@ -25,8 +25,8 @@ For non-linux users, there is a Dockerfile in this repo that builds a Linux cont
 This builds an image with the name `example-cpp-makefile`.
 
 #### 4. Create and run container with the image
-`docker run -e SRCCLR_CPP=true -e SRCCLR_API_TOKEN=<token> --rm -t --name example-cpp-makefile example-cpp-makefile`
+`docker run -e SRCCLR_API_TOKEN=<token> --rm -t --name example-cpp-makefile example-cpp-makefile`
 
-This creates a container with the name `example-cpp-makefile`, runs it and removes it after it has completed. The following environment variables are needed to scan the project:
-- `SRCCLR_CPP=true`: required to enable scanning Makefile projects as the feature is feature-flagged.
-- `SRCCLR_API_TOKEN=<token>`: your SourceClear API Token. Needed for scans to authenticate with SourceClear.
+This creates a container with the name `example-cpp-makefile`, runs it and removes it after it has completed.
+
+As shown in the example, setting `SRCCLR_API_TOKEN` to Veracode SCA API token is needed to scan the project.


### PR DESCRIPTION
The C/C++ scanning is no longer feature-flagged, so this removes the mention of SRCCLR_CPP in the README.